### PR TITLE
MacOS compilation modifications for fanckush's PR

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -128,61 +128,67 @@ The first step is to get all the dependencies as well as the source code:
 
 **NOTE:** xCode is not required but recommended. The Command Line tools that are implicitly installed with Homebrew are sufficient.
 
-1. a. Install the dependencies using [Homebrew](https://brew.sh):
+1. Install the official `git` package:
+https://git-scm.com/download/mac
+
+2. Install [Homebrew](https://brew.sh):
+https://brew.sh
+
+3. Install the dependencies:
 ``` bash
 brew install cmake boost exiv2 libraw qt libomp
 ```
-1. b. alglib is not available on brew (for now) so [Download ALGLIB 3.15.0 for C++](http://www.alglib.net/download.php) and extract to ~/alglib manually or:
+4. alglib is not available on brew (for now) so [Download ALGLIB 3.15.0 for C++](http://www.alglib.net/download.php) and extract to ~/alglib manually or:
 ``` bash
 mkdir ~/alglib && cd ~/alglib
 curl http://www.alglib.net/translator/re/alglib-3.15.0.cpp.gpl.zip --output ~/alglib/ALGLIB.zip
 unzip ~/alglib/ALGLIB.zip -d ~/alglib && rm ~/alglib/ALGLIB.zip
 ```
 
-1. c. Clone HDRMerge into ~/hdrmerge and checkout master branch
+5. Clone HDRMerge into ~/hdrmerge and checkout master branch
 ``` bash
 git clone https://github.com/jcelaya/hdrmerge.git ~/hdrmerge
 cd ~/hdrmerge
 git checkout master
 ```
-2. Make and go to the build directory.
+6. Make and go to the build directory.
 ``` bash
 mkdir ~/hdrmerge/build && cd ~/hdrmerge/build
 ```
-3. Issue cmake command
+7. Issue cmake command
 ``` bash
-cmake .. -DQt5_DIR=/usr/local/Cellar/Qt/5.12.3/lib/cmake/Qt5 -DCMAKE_BUILD_TYPE=Release -DOpenMP_C_FLAGS=-fopenmp=libiomp5 -DOpenMP_CXX_FLAGS=-fopenmp=libiomp5 -DOpenMP_C_LIB_NAMES="libiomp5" -DOpenMP_CXX_LIB_NAMES="libiomp5" -DOpenMP_libiomp5_LIBRARY="/usr/local/lib/libomp.dylib" -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include" -DOpenMP_CXX_LIB_NAMES="libiomp5" -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" -DCMAKE_OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk" -DALGLIB_ROOT=$HOME/alglib/cpp -DALGLIB_INCLUDES=$HOME/alglib/cpp/src -DALGLIB_LIBRARIES=$HOME/alglib/cpp/src -DCMAKE_INSTALL_BINDIR=$HOME/hdrmerge/build/install
+cmake .. -DQt5_DIR=/usr/local/Cellar/Qt/5.12.3/lib/cmake/Qt5 -DCMAKE_BUILD_TYPE=Release -DOpenMP_C_FLAGS=-fopenmp=libomp -DOpenMP_CXX_FLAGS=-fopenmp=libomp -DOpenMP_C_LIB_NAMES="libomp" -DOpenMP_CXX_LIB_NAMES="libomp" -DOpenMP_libomp_LIBRARY="/usr/local/lib/libomp.dylib" -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include" -DOpenMP_CXX_LIB_NAMES="libomp" -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON  -DALGLIB_ROOT=$HOME/alglib/cpp -DALGLIB_INCLUDES=$HOME/alglib/cpp/src -DALGLIB_LIBRARIES=$HOME/alglib/cpp/src -DCMAKE_INSTALL_BINDIR=$HOME/hdrmerge/build/install
 ```
 If the command fails then make sure the version of Qt from the command matches the one you have installed.
 
-4. Compile
+8. Compile
 ``` bash
-sudo make -j4 install
+make -j4 install
 ```
 
-5. Copy two of the dependencies into Frameworks.
+9. Copy two of the dependencies into Frameworks.
 ``` bash
-sudo mkdir ~/hdrmerge/build/install/hdrmerge.app/Contents/Frameworks
-sudo cp /usr/local/lib/libomp.dylib ~/hdrmerge/build/install/hdrmerge.app/Contents/Frameworks/.
-sudo cp /usr/local/lib/libexiv2.dylib ~/hdrmerge/build/install/hdrmerge.app/Contents/Frameworks/.
+mkdir ~/hdrmerge/build/install/hdrmerge.app/Contents/Frameworks
+cp /usr/local/lib/libomp.dylib ~/hdrmerge/build/install/hdrmerge.app/Contents/Frameworks/.
+cp /usr/local/lib/libexiv2.dylib ~/hdrmerge/build/install/hdrmerge.app/Contents/Frameworks/.
 ```
 
-6. Run Qt5's macdeployqt (adapt to your Qt version)
+10. Run Qt5's macdeployqt (adapt to your Qt version)
 ``` bash
-sudo /usr/local/Cellar/qt/5.12.3/bin/macdeployqt ~/hdrmerge/build/install/hdrmerge.app -no-strip -verbose=1
+/usr/local/Cellar/qt/5.12.3/bin/macdeployqt ~/hdrmerge/build/install/hdrmerge.app -no-strip -verbose=1
 ```
 
-7. Install an rpath
+11. Install an rpath
 ``` bash
-sudo install_name_tool -add_rpath "@executable_path/../Frameworks" ~/hdrmerge/build/install/hdrmerge.app/Contents/MacOS/hdrmerge
+install_name_tool -add_rpath "@executable_path/../Frameworks" ~/hdrmerge/build/install/hdrmerge.app/Contents/MacOS/hdrmerge
 ```
 
-8. Make the .dmg for further distribution (optional)
+12. Make the .dmg for further distribution (optional)
 ``` bash
 sudo hdiutil create -ov -srcfolder ~/hdrmerge/build/install/hdrmerge.app ~/hdrmerge/build/install/HDRMerge.dmg
 ```
 
 That was it! You can move the hdrmerge.app to you applications folder and start using it!
 ``` bash
-cp -r ~/hdrmerge/build/install/hdrmerge.app /Applications/HDRMerge.app
+ditto ~/hdrmerge/build/install/hdrmerge.app /Applications/HDRmerge.app
 ```


### PR DESCRIPTION
Install `git` before homebrew on systems sans Xcode installation.
Some `sudo`s not required for default toolchain build on Sierra+.
Remove SYSROOT from cmake command.
Swap `libiomp5` for `libomp` in cmake command.
`ditto` instead of `cp` to allow upgrades, in case `HDRmerge.app` was previously installed in `/Applications`.
Renumbered steps.